### PR TITLE
Add recipe-card-builder monorepo

### DIFF
--- a/recipe-card-builder/.github/workflows/ci.yml
+++ b/recipe-card-builder/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install frontend deps
+        run: |
+          cd frontend
+          npm install
+          npm run lint
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install deps
+        run: |
+          cd backend
+          poetry install
+      - name: Run tests
+        run: |
+          cd backend
+          poetry run pytest
+  frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install deps
+        run: |
+          cd frontend
+          npm install
+          npm run test -- --watchAll=false

--- a/recipe-card-builder/LICENSE
+++ b/recipe-card-builder/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Example
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipe-card-builder/backend/Dockerfile
+++ b/recipe-card-builder/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+ENV POETRY_VERSION=1.6.1
+
+RUN apt-get update && apt-get install -y build-essential libffi-dev libpq-dev libxml2-dev libxslt1-dev libjpeg-dev libpangocairo-1.0-0 libpangoft2-1.0-0 libcairo2 libpango1.0-dev && rm -rf /var/lib/apt/lists/*
+RUN pip install "poetry==$POETRY_VERSION"
+WORKDIR /app
+COPY pyproject.toml poetry.lock* /app/
+RUN poetry install --no-root
+RUN python -m spacy download en_core_web_sm
+COPY . /app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/recipe-card-builder/backend/app/api.py
+++ b/recipe-card-builder/backend/app/api.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import SQLModel, create_engine, Session, select
+
+from .models import Job, Recipe
+from .tasks import process_video
+
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+engine = create_engine(DATABASE_URL)
+
+router = APIRouter()
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session
+
+
+@router.post("/job")
+def create_job(url: str, target_lang: str, session: Session = Depends(get_session)) -> dict:
+    job = Job(id=str(uuid.uuid4()), video_url=url, target_lang=target_lang, status="pending")
+    session.add(job)
+    session.commit()
+    process_video.delay(job.id)
+    return {"job_id": job.id}
+
+
+@router.get("/job/{job_id}")
+def get_job(job_id: str, session: Session = Depends(get_session)) -> dict:
+    job = session.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    data = {"status": job.status}
+    if job.status == "completed":
+        data.update({"download_url": f"/static/cards/{job.recipe_id}.pdf", "recipe_id": job.recipe_id})
+    return data
+
+
+@router.get("/recipe/{recipe_id}")
+def get_recipe(recipe_id: str, session: Session = Depends(get_session)) -> Optional[Recipe]:
+    recipe = session.get(Recipe, recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return recipe

--- a/recipe-card-builder/backend/app/extract.py
+++ b/recipe-card-builder/backend/app/extract.py
@@ -1,0 +1,36 @@
+import re
+from typing import Dict, List
+
+import spacy
+
+nlp = spacy.load("en_core_web_sm")
+
+
+def parse_transcript(text: str) -> Dict[str, str]:
+    """Very naive rule-based extraction of recipe info."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    title = lines[0] if lines else "Recipe"
+    ingredients: List[str] = []
+    steps: List[str] = []
+    current = None
+    for line in lines[1:]:
+        lower = line.lower()
+        if "ingredient" in lower:
+            current = "ing"
+            continue
+        if any(word in lower for word in ["step", "instruction"]):
+            current = "step"
+            continue
+        if current == "ing":
+            ingredients.append(line)
+        elif current == "step":
+            steps.append(line)
+    servings_match = re.search(r"(serves|servings?):?\s*(\d+)", text, re.I)
+    cook_match = re.search(r"(cook time|cooking time):?\s*([\w\s]+)", text, re.I)
+    return {
+        "title": title,
+        "ingredients": str(ingredients),
+        "steps": str(steps),
+        "servings": servings_match.group(2) if servings_match else None,
+        "cook_time": cook_match.group(2) if cook_match else None,
+    }

--- a/recipe-card-builder/backend/app/main.py
+++ b/recipe-card-builder/backend/app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from .api import router as api_router
+
+app = FastAPI(title="Recipe Card Builder")
+
+app.mount("/api", api_router)
+app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/recipe-card-builder/backend/app/models.py
+++ b/recipe-card-builder/backend/app/models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional
+from sqlmodel import Field, SQLModel
+
+
+class Job(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    video_url: str
+    target_lang: str
+    status: str
+    recipe_id: Optional[str] = None
+
+
+class Recipe(SQLModel, table=True):
+    id: str = Field(primary_key=True)
+    video_id: str
+    title: str
+    ingredients: str
+    steps: str
+    servings: Optional[str] = None
+    cook_time: Optional[str] = None

--- a/recipe-card-builder/backend/app/tasks.py
+++ b/recipe-card-builder/backend/app/tasks.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+from celery import Celery
+from youtube_transcript_api import YouTubeTranscriptApi
+from langdetect import detect
+from transformers import pipeline
+from jinja2 import Environment, FileSystemLoader
+from weasyprint import HTML
+from sqlmodel import Session, create_engine, select
+
+from .models import Job, Recipe
+from .extract import parse_transcript
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+engine = create_engine(DATABASE_URL)
+
+celery_app = Celery("tasks", broker=REDIS_URL, backend=REDIS_URL)
+
+
+def translate_text(text: str, src: str, tgt: str) -> str:
+    if src == tgt:
+        return text
+    translator = pipeline("translation", model=f"Helsinki-NLP/opus-mt-{src}-{tgt}")
+    return translator(text, max_length=400)[0]["translation_text"]
+
+
+@celery_app.task()
+def process_video(job_id: str) -> None:
+    with Session(engine) as session:
+        job = session.get(Job, job_id)
+        if not job:
+            return
+        job.status = "in_progress"
+        session.add(job)
+        session.commit()
+        video_id = job.video_url.split("v=")[-1]
+        existing = session.exec(select(Recipe).where(Recipe.video_id == video_id)).first()
+        if existing:
+            job.status = "completed"
+            job.recipe_id = existing.id
+            session.commit()
+            return
+        try:
+            transcript_list = YouTubeTranscriptApi.get_transcript(video_id)
+        except Exception:
+            job.status = "failed"
+            session.commit()
+            return
+        transcript_text = " ".join(chunk["text"] for chunk in transcript_list)
+        src_lang = detect(transcript_text)
+        try:
+            if src_lang != "en" and job.target_lang != "en":
+                text_en = translate_text(transcript_text, src_lang, "en")
+                translated = translate_text(text_en, "en", job.target_lang)
+            else:
+                translated = translate_text(transcript_text, src_lang, job.target_lang)
+        except Exception:
+            job.status = "failed"
+            session.commit()
+            return
+        recipe_data = parse_transcript(translated)
+        recipe = Recipe(
+            id=str(uuid.uuid4()),
+            video_id=video_id,
+            title=recipe_data.get("title", ""),
+            ingredients=recipe_data.get("ingredients", "[]"),
+            steps=recipe_data.get("steps", "[]"),
+            servings=recipe_data.get("servings"),
+            cook_time=recipe_data.get("cook_time"),
+        )
+        session.add(recipe)
+        job.status = "completed"
+        job.recipe_id = recipe.id
+        session.commit()
+        env = Environment(loader=FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")))
+        template = env.get_template("card.html")
+        html_str = template.render(recipe=recipe)
+        output_dir = os.path.join(os.path.dirname(__file__), "static", "cards")
+        os.makedirs(output_dir, exist_ok=True)
+        pdf_path = os.path.join(output_dir, f"{recipe.id}.pdf")
+        HTML(string=html_str).write_pdf(pdf_path)

--- a/recipe-card-builder/backend/app/templates/card.html
+++ b/recipe-card-builder/backend/app/templates/card.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ recipe.title }}</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+h1 { text-align: center; }
+ul { list-style: disc; margin-left: 20px; }
+.step { margin-bottom: 10px; }
+</style>
+</head>
+<body>
+<h1>{{ recipe.title }}</h1>
+<p><strong>Servings:</strong> {{ recipe.servings or 'N/A' }}<br>
+<strong>Cook Time:</strong> {{ recipe.cook_time or 'N/A' }}</p>
+<h2>Ingredients</h2>
+<ul>
+{% for ing in recipe.ingredients|safe|eval %}
+<li>{{ ing }}</li>
+{% endfor %}
+</ul>
+<h2>Steps</h2>
+<ol>
+{% for step in recipe.steps|safe|eval %}
+<li class="step">{{ step }}</li>
+{% endfor %}
+</ol>
+</body>
+</html>

--- a/recipe-card-builder/backend/pyproject.toml
+++ b/recipe-card-builder/backend/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.poetry]
+name = "recipe-backend"
+version = "0.1.0"
+description = "Backend for Recipe Card Builder"
+authors = ["Example <example@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "0.110.0"
+uvicorn = {version = "0.27.1", extras = ["standard"]}
+SQLModel = "0.0.16"
+sqlalchemy = "2.0.28"
+redis = "5.0.1"
+celery = "5.3.6"
+youtube-transcript-api = "0.6.2"
+spacy = "3.7.2"
+jinja2 = "3.1.3"
+weasyprint = "60.2"
+langdetect = "1.0.9"
+psycopg2-binary = "2.9.9"
+transformers = "4.37.1"
+torch = "2.1.2"
+
+[tool.poetry.dev-dependencies]
+pytest = "8.1.1"
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"

--- a/recipe-card-builder/backend/tests/test_api.py
+++ b/recipe-card-builder/backend/tests/test_api.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+
+from app.main import app
+from app.api import get_session
+
+engine = create_engine("sqlite:///:memory:")
+SQLModel.metadata.create_all(engine)
+
+
+def override_session():
+    with Session(engine) as session:
+        yield session
+
+app.dependency_overrides[get_session] = override_session
+client = TestClient(app)
+
+
+def test_create_job(monkeypatch):
+    def fake_delay(job_id: str):
+        return None
+
+    monkeypatch.setattr("app.tasks.process_video.delay", fake_delay)
+    response = client.post("/api/job", params={"url": "https://youtu.be/123", "target_lang": "en"})
+    assert response.status_code == 200
+    assert "job_id" in response.json()

--- a/recipe-card-builder/backend/tests/test_extract.py
+++ b/recipe-card-builder/backend/tests/test_extract.py
@@ -1,0 +1,14 @@
+from app.extract import parse_transcript
+
+
+def test_parse_transcript():
+    text = """Best Pancakes
+Ingredients
+flour
+milk
+Step
+mix
+cook"""
+    data = parse_transcript(text)
+    assert "flour" in data["ingredients"]
+    assert "mix" in data["steps"]

--- a/recipe-card-builder/backend/tests/test_translation.py
+++ b/recipe-card-builder/backend/tests/test_translation.py
@@ -1,0 +1,7 @@
+from app.tasks import translate_text
+
+
+def test_translate_text():
+    result = translate_text("Hello world", "en", "de")
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/recipe-card-builder/docker-compose.yml
+++ b/recipe-card-builder/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: recipe
+      POSTGRES_PASSWORD: recipe
+      POSTGRES_DB: recipe
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+  backend:
+    build: ./backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ./backend:/app
+      - ./backend/static:/app/static
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://recipe:recipe@db/recipe
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
+    ports:
+      - "8000:8000"
+  worker:
+    build: ./backend
+    command: celery -A app.tasks worker --loglevel=info
+    volumes:
+      - ./backend:/app
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://recipe:recipe@db/recipe
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
+  frontend:
+    image: node:20
+    working_dir: /app
+    command: sh -c "npm install && npm run dev"
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+volumes:
+  db_data:

--- a/recipe-card-builder/frontend/.eslintrc.json
+++ b/recipe-card-builder/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/recipe-card-builder/frontend/.prettierrc
+++ b/recipe-card-builder/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/recipe-card-builder/frontend/components/ProgressBar.tsx
+++ b/recipe-card-builder/frontend/components/ProgressBar.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  status: string;
+}
+
+export default function ProgressBar({ status }: Props) {
+  const color =
+    status === 'completed'
+      ? 'bg-green-500'
+      : status === 'failed'
+      ? 'bg-red-500'
+      : status === 'in_progress'
+      ? 'bg-yellow-500'
+      : 'bg-gray-300';
+  return <div className={`w-full h-2 ${color}`}></div>;
+}

--- a/recipe-card-builder/frontend/components/RecipeEditor.tsx
+++ b/recipe-card-builder/frontend/components/RecipeEditor.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  recipeId: string;
+}
+
+interface Recipe {
+  title: string;
+  ingredients: string;
+  steps: string;
+  servings?: string;
+  cook_time?: string;
+}
+
+export default function RecipeEditor({ recipeId }: Props) {
+  const [recipe, setRecipe] = useState<Recipe | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/recipe/${recipeId}`)
+      .then((res) => res.json())
+      .then((data) => setRecipe(data));
+  }, [recipeId]);
+
+  if (!recipe) return null;
+
+  return (
+    <div className="mt-4 space-y-2">
+      <input
+        className="border p-2 w-full"
+        value={recipe.title}
+        onChange={(e) => setRecipe({ ...recipe, title: e.target.value })}
+      />
+      <textarea
+        className="border p-2 w-full"
+        value={recipe.ingredients}
+        onChange={(e) => setRecipe({ ...recipe, ingredients: e.target.value })}
+      />
+      <textarea
+        className="border p-2 w-full"
+        value={recipe.steps}
+        onChange={(e) => setRecipe({ ...recipe, steps: e.target.value })}
+      />
+    </div>
+  );
+}

--- a/recipe-card-builder/frontend/jest.config.js
+++ b/recipe-card-builder/frontend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/recipe-card-builder/frontend/jest.setup.js
+++ b/recipe-card-builder/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/recipe-card-builder/frontend/next-env.d.ts
+++ b/recipe-card-builder/frontend/next-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+declare module 'papaparse';
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/recipe-card-builder/frontend/package.json
+++ b/recipe-card-builder/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "recipe-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "3.4.1",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "@shadcn/ui": "0.3.5"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "eslint": "8.55.0",
+    "eslint-config-next": "14.0.4",
+    "jest": "29.7.0",
+    "@types/react": "18.2.33",
+    "@types/node": "20.11.17",
+    "@types/jest": "29.5.4",
+    "prettier": "3.2.5"
+  }
+}

--- a/recipe-card-builder/frontend/pages/_app.tsx
+++ b/recipe-card-builder/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/recipe-card-builder/frontend/pages/batch.tsx
+++ b/recipe-card-builder/frontend/pages/batch.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import Papa from 'papaparse';
+import ProgressBar from '../components/ProgressBar';
+
+interface Row {
+  url: string;
+  target_lang: string;
+  job_id?: string;
+  status?: string;
+}
+
+export default function Batch() {
+  const [rows, setRows] = useState<Row[]>([]);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    Papa.parse<Row>(file, {
+      header: true,
+      complete: (res) => {
+        setRows(res.data);
+      },
+    });
+  };
+
+  const startJobs = async () => {
+    const updated = await Promise.all(
+      rows.map(async (row) => {
+        const res = await fetch('/api/job', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: row.url, target_lang: row.target_lang }),
+        });
+        const data = await res.json();
+        return { ...row, job_id: data.job_id, status: 'pending' };
+      })
+    );
+    setRows(updated);
+  };
+
+  const poll = async (row: Row) => {
+    if (!row.job_id) return row;
+    const res = await fetch(`/api/job/${row.job_id}`);
+    const data = await res.json();
+    return { ...row, status: data.status };
+  };
+
+  const refresh = async () => {
+    const updated = await Promise.all(rows.map(poll));
+    setRows(updated);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <input type="file" accept=".csv" onChange={handleFile} />
+      <button className="bg-blue-500 text-white px-4 py-2" onClick={startJobs}>
+        Start Jobs
+      </button>
+      <button className="ml-2 border px-2" onClick={refresh}>
+        Refresh
+      </button>
+      <table className="table-auto w-full mt-4 border">
+        <thead>
+          <tr>
+            <th className="border px-2">URL</th>
+            <th className="border px-2">Target</th>
+            <th className="border px-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => (
+            <tr key={idx} className="border">
+              <td className="border px-2">{row.url}</td>
+              <td className="border px-2">{row.target_lang}</td>
+              <td className="border px-2">
+                {row.status && <ProgressBar status={row.status} />}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/recipe-card-builder/frontend/pages/index.tsx
+++ b/recipe-card-builder/frontend/pages/index.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import ProgressBar from '../components/ProgressBar';
+import RecipeEditor from '../components/RecipeEditor';
+
+export default function Home() {
+  const [url, setUrl] = useState('');
+  const [lang, setLang] = useState('en');
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [status, setStatus] = useState('pending');
+  const [recipeId, setRecipeId] = useState<string | null>(null);
+
+  const pollStatus = async (id: string) => {
+    const res = await fetch(`/api/job/${id}`);
+    const data = await res.json();
+    setStatus(data.status);
+    if (data.status === 'completed') {
+      setRecipeId(data.recipe_id);
+    }
+  };
+
+  const handleGenerate = async () => {
+    const res = await fetch('/api/job', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, target_lang: lang }),
+    });
+    const data = await res.json();
+    setJobId(data.job_id);
+    setStatus('pending');
+    const interval = setInterval(async () => {
+      await pollStatus(data.job_id);
+      if (status === 'completed' || status === 'failed') {
+        clearInterval(interval);
+      }
+    }, 2000);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <input
+          className="border p-2 mr-2"
+          placeholder="YouTube URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <select
+          className="border p-2 mr-2"
+          value={lang}
+          onChange={(e) => setLang(e.target.value)}
+        >
+          <option value="en">English</option>
+          <option value="de">German</option>
+          <option value="es">Spanish</option>
+        </select>
+        <button className="bg-blue-500 text-white px-4 py-2" onClick={handleGenerate}>
+          Generate
+        </button>
+      </div>
+      {jobId && <ProgressBar status={status} />}
+      {status === 'completed' && recipeId && (
+        <div>
+          <a href={`/static/cards/${recipeId}.pdf`} className="underline">
+            Download PDF
+          </a>
+          <RecipeEditor recipeId={recipeId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/recipe-card-builder/frontend/postcss.config.js
+++ b/recipe-card-builder/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/recipe-card-builder/frontend/styles/globals.css
+++ b/recipe-card-builder/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/recipe-card-builder/frontend/tailwind.config.js
+++ b/recipe-card-builder/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./pages/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/recipe-card-builder/frontend/tsconfig.json
+++ b/recipe-card-builder/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap monorepo `recipe-card-builder` with backend and frontend apps
- backend uses FastAPI with Celery tasks for YouTube transcript recipes
- frontend provides simple interface with Next.js and Tailwind
- add CI skeleton for lint and tests

## Testing
- `poetry install` *(fails: version solving / heavy deps)*


------
https://chatgpt.com/codex/tasks/task_b_6853016aa65c832b8bc96dcf09ed216b